### PR TITLE
Add ccache to gcc and clang images

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The generated images are used by Jenkins to test the AutoPas library.
 ### archer
 This file is used to check OpenMP data races. It uses the [archer data race detection tool](https://github.com/PRUNERS/archer). The file includes:
 * make
+* ccache
 * cmake
 * ninja
 * clang v6.0.0
@@ -51,6 +52,7 @@ This file is used for code coverage purposes. You can build AutoPas in a code-co
 * ninja
 * lcov + gcov
 * gcovr
+* ccache
 
 ### cuda
 This file is used to build the AutoPas library using cuda. It contains:

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ As Archer already sets -fopenmp OpenMP will always be automatically enabled with
 ### clang
 This file is used to build the AutoPas library using clang. It contains:
 * make
+* ccache
 * cmake
 * ninja
 * clang v6.0
@@ -63,7 +64,7 @@ This file is used to build the doxygen documentation. It includes:
 * make
 * cmake
 * doxygen
-* graphviz 
+* graphviz
 
 ### gcc
 This file is used to build the AutoPas library using gcc. It contains:
@@ -72,6 +73,7 @@ This file is used to build the AutoPas library using gcc. It contains:
 * cmake
 * ninja
 * openmpi
+* ccache
 
 ## other uses
 Many of the provided Doxygen images / Doxyfiles can be used to build other things. Feel free to grab them and use them for your own purposes.

--- a/buildenv/archer/Dockerfile
+++ b/buildenv/archer/Dockerfile
@@ -10,6 +10,7 @@ RUN true \
 		wget \
 		gdb \
 		git \
+		ccache \
 	&& rm -rf /var/lib/apt/lists/*
 # install current cmake
 RUN pip install --upgrade pip
@@ -85,4 +86,3 @@ RUN cmake -G Ninja \
  ..
 RUN ninja
 RUN ninja install
-

--- a/buildenv/clang/Dockerfile
+++ b/buildenv/clang/Dockerfile
@@ -5,6 +5,7 @@ RUN true \
 	&& apt-get -qq update \
 	&& apt-get -qq install -y --no-install-recommends \
 		build-essential \
+		ccache \
 		python-pip \
 		ninja-build \
 		wget \
@@ -38,4 +39,3 @@ RUN true \
 RUN ln -s /usr/bin/clang-${CLANGVERSION} /usr/bin/clang
 RUN ln -s /usr/bin/clang++-${CLANGVERSION} /usr/bin/clang++
 RUN ln -s /usr/bin/llvm-config-${CLANGVERSION} /usr/bin/llvm-config
-

--- a/buildenv/code-coverage/Dockerfile
+++ b/buildenv/code-coverage/Dockerfile
@@ -7,6 +7,7 @@ RUN true \
 		python \
 		lcov \
 		gcovr \
+		ccache \
 	&& rm -rf /var/lib/apt/lists/*
 
 

--- a/buildenv/gcc/Dockerfile
+++ b/buildenv/gcc/Dockerfile
@@ -3,6 +3,7 @@ FROM purplekarrot/gcc-7
 RUN true \
 	&& apt-get -qq update \
 	&& apt-get -qq install -y --no-install-recommends \
+		ccache \
 		libopenmpi-dev \
 	&& rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
This adds ccache to the clang and gcc images. I'm not sure about the others, should they have it as well? I didn't find anything concerning ccache and archer, for example.

Are the images rebuilt and deployed automagically?