### PR TITLE
Added python3-dev to the installations.

### DIFF
--- a/buildenv/base/Dockerfile
+++ b/buildenv/base/Dockerfile
@@ -18,6 +18,7 @@ RUN true \
         ssh \
         vim \
         wget \
+        python3-dev \
 # install AutoPas dependencies so we don't rely on bundled versions
         libeigen3-dev \
         libyaml-cpp-dev \

--- a/buildenv/clang/Dockerfile
+++ b/buildenv/clang/Dockerfile
@@ -21,6 +21,7 @@ RUN true \
         clang-format-${CLANGVERSION} \
         python3-pip \
         python3-setuptools \
+        python3-dev \
     && rm -rf /var/lib/apt/lists/*
 RUN pip3 install --upgrade cmake-format
 

--- a/buildenv/doxygen/Dockerfile
+++ b/buildenv/doxygen/Dockerfile
@@ -9,6 +9,7 @@ RUN true \
         python3 \
         flex \
         bison \
+        python3-dev \
     && rm -rf /var/lib/apt/lists/*
 
 RUN update-ca-certificates

--- a/buildenv/gcc/Dockerfile
+++ b/buildenv/gcc/Dockerfile
@@ -10,6 +10,7 @@ RUN true \
     && apt-get -qq install -y --no-install-recommends \
         libmpich-dev \
         software-properties-common \
+        python3-dev \
     && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
     && apt-get -qq update \
     && apt-get -qq install -y --no-install-recommends \


### PR DESCRIPTION
Added python3-dev among the list of packages installed for the build environments in order to successfully compile decision tree tuning strategy which uses Python header files. I tested it to see if it resolves the error message, and it does.