### PR TITLE
Decision tree tuning adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This file is used to check OpenMP data races. It uses the [archer data race dete
 * cmake
 * ninja
 * clang
+* python3-dev
 * llvm openmp library (v10) with bundled archer - it is automatically loaded when clang is used as compiler.
 
 **Important**: `export TSAN_OPTIONS="ignore_noninstrumented_modules=1"` is recommended for archer.
@@ -30,6 +31,7 @@ This file is used to build the AutoPas library using clang. It contains:
 * clang
 * libomp
 * clang-format
+* python3-dev
 
 ### code-coverage
 
@@ -48,6 +50,7 @@ This file is used to build the doxygen documentation. It includes:
 * cmake
 * doxygen
 * graphviz
+* python3-dev
 
 ### gcc
 This file is used to build the AutoPas library using gcc. It contains:
@@ -58,6 +61,7 @@ This file is used to build the AutoPas library using gcc. It contains:
 * mpich
 * ccache
 * lcov
+* python3-dev
 
 ## other uses
 Many of the provided Doxygen images / Doxyfiles can be used to build other things. Feel free to grab them and use them for your own purposes.

--- a/buildenv/archer/Dockerfile
+++ b/buildenv/archer/Dockerfile
@@ -15,13 +15,14 @@ deb-src http://apt.llvm.org/${UBUNTUVERSION}/ llvm-toolchain-${UBUNTUVERSION}-${
 # add llvm repo key
 RUN wget --no-check-certificate -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 
-# install clang and llvm
+# install clang llvm and python3-dev
 RUN true \
     && apt-get -qq update \
     && apt-get -qq install -y --no-install-recommends \
         clang-${CLANGVERSION} \
         lldb-${CLANGVERSION} \
         unzip \
+	    python3-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # generate links to clang

--- a/buildenv/base/Dockerfile
+++ b/buildenv/base/Dockerfile
@@ -18,6 +18,7 @@ RUN true \
         ssh \
         vim \
         wget \
+        python3-dev \
 # install AutoPas dependencies so we don't rely on bundled versions
         libeigen3-dev \
         libyaml-cpp-dev \

--- a/buildenv/clang/Dockerfile
+++ b/buildenv/clang/Dockerfile
@@ -21,6 +21,7 @@ RUN true \
         clang-format-${CLANGVERSION} \
         python3-pip \
         python3-setuptools \
+        python3-dev \
     && rm -rf /var/lib/apt/lists/*
 RUN pip3 install --upgrade cmake-format
 

--- a/buildenv/doxygen/Dockerfile
+++ b/buildenv/doxygen/Dockerfile
@@ -9,6 +9,7 @@ RUN true \
         python3 \
         flex \
         bison \
+        python3-dev \
     && rm -rf /var/lib/apt/lists/*
 
 RUN update-ca-certificates

--- a/buildenv/gcc/Dockerfile
+++ b/buildenv/gcc/Dockerfile
@@ -10,6 +10,7 @@ RUN true \
     && apt-get -qq install -y --no-install-recommends \
         libmpich-dev \
         software-properties-common \
+        python3-dev \
     && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
     && apt-get -qq update \
     && apt-get -qq install -y --no-install-recommends \


### PR DESCRIPTION
Added python3-dev installation to the archer Dockerfile as it doesn't seem to import it from the base Dockerfile. Tested locally, and adding python3-dev line seems to fix the error of Python headers not being found while compiling, which also caused the jobs to fail on remote.