### PR TITLE
Update dockerfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ This file is used to check OpenMP data races. It uses the [archer data race dete
 * cmake
 * ninja
 * clang
-* python3-dev
+* pybind11-dev
+* nlohmann-json3-dev
 * llvm openmp library (v10) with bundled archer - it is automatically loaded when clang is used as compiler.
 
 **Important**: `export TSAN_OPTIONS="ignore_noninstrumented_modules=1"` is recommended for archer.
@@ -31,7 +32,8 @@ This file is used to build the AutoPas library using clang. It contains:
 * clang
 * libomp
 * clang-format
-* python3-dev
+* pybind11-dev
+* nlohmann-json3-dev
 
 ### code-coverage
 
@@ -50,7 +52,8 @@ This file is used to build the doxygen documentation. It includes:
 * cmake
 * doxygen
 * graphviz
-* python3-dev
+* pybind11-dev
+* nlohmann-json3-dev
 
 ### gcc
 This file is used to build the AutoPas library using gcc. It contains:
@@ -61,7 +64,8 @@ This file is used to build the AutoPas library using gcc. It contains:
 * mpich
 * ccache
 * lcov
-* python3-dev
+* pybind11-dev
+* nlohmann-json3-dev
 
 ## other uses
 Many of the provided Doxygen images / Doxyfiles can be used to build other things. Feel free to grab them and use them for your own purposes.

--- a/buildenv/base/Dockerfile
+++ b/buildenv/base/Dockerfile
@@ -18,13 +18,19 @@ RUN true \
         ssh \
         vim \
         wget \
-        python3-dev \
+        pybind11-dev \
+        nlohmann-json3-dev \
 # install AutoPas dependencies so we don't rely on bundled versions
         libeigen3-dev \
         libyaml-cpp-dev \
         # libspdlog-dev \ <- version too old. Needs at least 1.3.1
         # needed for bundled antlr4 (rule based tuning parser engine)
         uuid-dev \
+        python3 \
+        python3-pip \
+        python3-dev \
+        python3-setuptools \
+        python3-distutils \
     && rm -rf /var/lib/apt/lists/*
 
 # we might want to fix the certificate stuff
@@ -62,6 +68,10 @@ RUN wget --no-verbose -O spdlog.tgz https://github.com/gabime/spdlog/archive/v1.
         -DSPDLOG_BUILD_TESTS=OFF \
     && make install -j4
 
+# Update Python and ensure pip and setuptools are up to date
+RUN python3 -m pip install --upgrade pip setuptools wheel
+
+# Add ccache and entrypoint script
 COPY bin/entrypoint.sh /usr/local/bin
 RUN ln -s /usr/local/bin/entrypoint.sh / # backwards compat
 RUN mkdir -p /ccache_default_dir

--- a/buildenv/gcc/Dockerfile
+++ b/buildenv/gcc/Dockerfile
@@ -10,16 +10,23 @@ RUN true \
     && apt-get -qq install -y --no-install-recommends \
         libmpich-dev \
         software-properties-common \
-        python3-dev \
+        python3.8 python3.8-dev python3.8-distutils python3.8-venv python3-pip \
+        pybind11-dev \
+        nlohmann-json3-dev \
     && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
     && apt-get -qq update \
     && apt-get -qq install -y --no-install-recommends \
         g++-${GCCVERSION} \
     && rm -rf /var/lib/apt/lists/* \
     && ln -s -f /usr/bin/gcc-${GCCVERSION} /usr/bin/gcc \
-    && ln -s -f /usr/bin/g++-${GCCVERSION} /usr/bin/g++
+    && ln -s -f /usr/bin/g++-${GCCVERSION} /usr/bin/g++ \
+    && ln -sf /usr/bin/python3.8 /usr/bin/python3
 
-# install lcov and set gcov-11
+# Upgrade Python pip, setuptools, and wheel
+RUN python3 -m pip install --no-cache-dir --upgrade pip setuptools wheel \
+    && python3 -m pip install --no-cache-dir numpy pandas
+
+# Install lcov and set gcov-11
 RUN cd \
     && perl -MCPAN -e 'install(Capture::Tiny, DateTime, Date::Parse, Cpanel::JSON::XS)' \
     && git clone https://github.com/linux-test-project/lcov.git \


### PR DESCRIPTION
I've updated the base and gcc dockerfiles and the documentation for the migration from C/Python API to `pybind11`. 

I have added the gcc Dockerfile only for reference. Ideally, you would publish the image `autopas/build-base` image on Dockerhub and all dockerfiles which inherit it (`archer`, `clang`, `code-coverage`, `doxygen`, `gcc`) should have `pybind11` and `nlohmann-json3-dev` installed without adding those lines since they inherit from that image.

If you wouldn't want to include these packages in the `README` for these dockerfiles, please delete the lines I've added.