### PR TITLE
Update Archer's Clang Version to 13

### DIFF
--- a/buildenv/archer/Dockerfile
+++ b/buildenv/archer/Dockerfile
@@ -6,7 +6,7 @@ RUN true \
         ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-ENV CLANGVERSION 10
+ENV CLANGVERSION 13
 
 # add llvm repository
 RUN echo "deb http://apt.llvm.org/${UBUNTUVERSION}/ llvm-toolchain-${UBUNTUVERSION}-${CLANGVERSION} main\n\


### PR DESCRIPTION
The `autopas-build-archer`'s clang version is only 10 - but we say that we support minimum clang 13 and this is the version used in the `autopas-build-clang`'s clang version. Somehow this hasn't caused any problems so far but I now want to upgrade `yaml-cpp` and it won't build with clang-10.