### PR TITLE
Upgrade clang to 17

### DIFF
--- a/buildenv/archer/Dockerfile
+++ b/buildenv/archer/Dockerfile
@@ -6,7 +6,7 @@ RUN true \
         ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-ENV CLANGVERSION=16
+ENV CLANGVERSION=17
 
 # If needed in future: add llvm repository (can be used to get newer versions of clang)
 # RUN echo "deb http://apt.llvm.org/${UBUNTUVERSION}/ llvm-toolchain-${UBUNTUVERSION}-${CLANGVERSION} main\n\

--- a/buildenv/clang/Dockerfile
+++ b/buildenv/clang/Dockerfile
@@ -1,6 +1,6 @@
 FROM autopas/build-base
 
-ENV CLANGVERSION=16
+ENV CLANGVERSION=17
 
 # If needed in future: add llvm repository (can be used to get newer versions of clang)
 # RUN echo "deb http://apt.llvm.org/${UBUNTUVERSION}/ llvm-toolchain-${UBUNTUVERSION}-${CLANGVERSION} main\n\


### PR DESCRIPTION
Upgrades clang to v17. Supported by clusters commonly used (HSUper, v17; CoolMUC4, v19)